### PR TITLE
'tildeop' breaks preserving the case of the small camel

### DIFF
--- a/autoload/textobj/variable_segment.vim
+++ b/autoload/textobj/variable_segment.vim
@@ -38,7 +38,10 @@ function! s:select_a()
         if start_column - 2 <= word_start ||
          \ getline(start_line)[:start_column - 2] =~# '^_*$'
             call setpos('.', end_position)
+            let l:tildeop = &tildeop
+            set notildeop
             normal! l~
+            let &tildeop = l:tildeop
         endif
     endif
 

--- a/t/variable-segment.vim
+++ b/t/variable-segment.vim
@@ -404,4 +404,13 @@ describe 'av'
         normal dav
         Expect getline(1) == 'foo bazQuux'
     end
+    it 'selects leading small camels and swaps case even with tildeop'
+        set tildeop  " Vim default is notildeop
+        put! = 'fooBarQuux'
+        normal! 0
+        normal dav
+        Expect getline(1) == 'barQuux'
+        Expect &tildeop == 1
+        set notildeop
+    end
 end


### PR DESCRIPTION
When `'tildeop'` is set the command `normal! l~` doesn't work. This PR backs up the option, sets `'notildeop'`, and restores it afterwards. 